### PR TITLE
Lazy loading of GravityForms models

### DIFF
--- a/lib/ruby-wpdb.rb
+++ b/lib/ruby-wpdb.rb
@@ -45,8 +45,6 @@ module WPDB
       require_relative 'ruby-wpdb/comments'
       require_relative 'ruby-wpdb/links'
       require_relative 'ruby-wpdb/gravityforms'
-
-      WPDB::GravityForms::ModelGenerator.new.generate
     end
   end
 end

--- a/lib/ruby-wpdb/gravityforms.rb
+++ b/lib/ruby-wpdb/gravityforms.rb
@@ -82,7 +82,7 @@ module WPDB
       attr_reader :models
 
       def initialize(forms = nil)
-        @forms = forms || Form.all
+        @forms = Array(forms) || Form.all
         @models = []
       end
 
@@ -166,6 +166,24 @@ module WPDB
 
         dataset
       end
+    end
+
+    # When a request is made to, for example,
+    # WPDB::GravityForms::SomeClass, this method will fire. If there's
+    # a GravityForm whose title, when camelised, is "SomeClass", a model
+    # will be created for that form.
+    #
+    # After the first time, the constant for that form will have been
+    # created, and so this hook will no longer fire.
+    def self.const_missing(name)
+      Form.each do |form|
+        if name.to_s == WPDB.camelize(form.title)
+          ModelGenerator.new(form).generate
+          return WPDB::GravityForms.const_get(name)
+        end
+      end
+
+      raise "Form not found: #{name}"
     end
   end
 

--- a/test/gravityforms_test.rb
+++ b/test/gravityforms_test.rb
@@ -3,6 +3,7 @@ require_relative 'test_helper'
 describe WPDB::GravityForms do
   before do
     @form = WPDB::GravityForms::Form.first
+    @class_name = WPDB.camelize(@form.title).to_sym
   end
 
   it "fetches a form" do
@@ -15,5 +16,10 @@ describe WPDB::GravityForms do
 
   it "associates lead detail with a lead" do
     assert @form.leads.first.details.length
+  end
+
+  it "lazily loads models for forms" do
+    klass = WPDB::GravityForms.const_get(@class_name)
+    assert_equal Class, klass.class
   end
 end


### PR DESCRIPTION
Creating models for all GravityForms every time we run can slow things down significantly. We should use `const_missing` on `WPDB::GravityForms` to only load them when necessary.
