### PR TITLE
Remove the require of pry-debugger from the root file

### DIFF
--- a/lib/ruby-wpdb.rb
+++ b/lib/ruby-wpdb.rb
@@ -2,7 +2,6 @@ require 'bundler/setup'
 
 require 'sequel'
 require 'pry'
-require 'pry-debugger'
 
 module WPDB
   class << self


### PR DESCRIPTION
pry-debugger is specified as a development dependency in the gemspec, but is required in the root file (lib/ruby-wpdb.rb). This results in load errors when requiring the gem.

Here's the irb stack trace: 

```
> require 'ruby-wpdb'
LoadError: cannot load such file -- pry-debugger
  from /Users/dxwduncan/.rvm/gems/ruby-1.9.3-p448/gems/ruby-wpdb-1.0/lib/ruby-wpdb.rb:5:in `require'
  from /Users/dxwduncan/.rvm/gems/ruby-1.9.3-p448/gems/ruby-wpdb-1.0/lib/ruby-wpdb.rb:5:in `<top (required)>'
  from (irb):3:in `require'
```
