### PR TITLE
Parser for wp-config files

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,2 @@
 query.log
+wp-config-sample.php

--- a/lib/ruby-wpdb.rb
+++ b/lib/ruby-wpdb.rb
@@ -2,6 +2,9 @@ require 'bundler/setup'
 
 require 'sequel'
 require 'pry'
+require 'pathname'
+
+require_relative 'ruby-wpdb/config'
 
 module WPDB
   class << self
@@ -11,15 +14,16 @@ module WPDB
     # config files found in that file.
     def from_config(file = nil)
       file ||= File.dirname(__FILE__) + '/../config.yml'
-      config = YAML::load_file(file)
+      file = Pathname(file)
 
-      uri  = 'mysql2://'
-      uri += "#{config['username']}:#{config['password']}"
-      uri += "@#{config['hostname']}"
-      uri += ":#{config['port']}" if config['port']
-      uri += "/#{config['database']}"
+      case file.extname
+      when ".yml"
+        config_file = Config::YAML.new(file)
+      when ".php"
+        config_file = Config::WPConfig.new(file)
+      end
 
-      init(uri, config['prefix'])
+      init(config_file.config[:uri], config_file.config[:prefix])
     end
 
     # Initialises Sequel, sets up some necessary variables (like

--- a/lib/ruby-wpdb/config.rb
+++ b/lib/ruby-wpdb/config.rb
@@ -1,0 +1,55 @@
+module WPDB
+  module Config
+    class YAML
+      def initialize(file)
+        if file.respond_to? :read
+          @contents = file.read
+        else
+          @contents = File.read(file)
+        end
+
+        parse
+      end
+
+      def parse
+        @config = ::YAML::load(@contents)
+      end
+
+      def config
+        uri  = 'mysql2://'
+        uri += "#{@config['username']}:#{@config['password']}"
+        uri += "@#{@config['hostname']}"
+        uri += ":#{@config['port']}" if @config['port']
+        uri += "/#{@config['database']}"
+
+        { uri: uri, prefix: @config['prefix'] }
+      end
+    end
+
+    class WPConfig
+      def initialize(file)
+        if file.respond_to? :read
+          @contents = file.read
+        else
+          @contents = File.read(file)
+        end
+
+        parse
+      end
+
+      def parse
+        @config = Hash[@contents.scan(/define\((?:'|")(.+)(?:'|"), *(?:'|")(.+)(?:'|")\)/)]
+        @config['DB_PREFIX'] ||= 'wp_'
+      end
+
+      def config
+        uri  = 'mysql2://'
+        uri += "#{@config['DB_USER']}:#{@config['DB_PASSWORD']}"
+        uri += "@#{@config['DB_HOST']}"
+        uri += "/#{@config['DB_NAME']}"
+
+        { uri: uri, prefix: @config['DB_PREFIX'] }
+      end
+    end
+  end
+end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,20 @@
+require_relative 'test_helper'
+
+require "open-uri"
+
+describe "Config" do
+  it "correctly parses the sample wp-config" do
+    sample_config = Pathname(__FILE__) + ".." + ".." + "data" + "wp-config-sample.php"
+    live_url = "https://raw.githubusercontent.com/WordPress/WordPress/master/wp-config-sample.php"
+    open(live_url) do |live|
+      File.open(sample_config, "w") do |f|
+        f.write live.read
+      end
+    end
+
+    config = WPDB::Config::WPConfig.new(sample_config).config
+
+    assert_equal "mysql2://username_here:password_here@localhost/database_name_here", config[:uri]
+    assert_equal "wp_", config[:prefix]
+  end
+end


### PR DESCRIPTION
Like `WPDB.from_config` (that takes a YAML file), there should be a way to instantiate ruby-wpdb by passing it the path to a `wp-config.php`, which is then parsed for its database connection settings.
