### PR TITLE
If console is started in a WordPress directory, use its wp-config.php

### DIFF
--- a/bin/ruby-wpdb
+++ b/bin/ruby-wpdb
@@ -15,8 +15,10 @@ module WPDB
 
     desc "console", "Runs an interactive ruby-wpdb console"
     def console
-      if options[:config_file]
+      begin
         WPDB.from_config(options[:config_file])
+      rescue WPDB::ConfigFileError
+        puts "I couldn't find a config file, so you'll need to specify one manually."
       end
 
       Pry.config.should_load_rc = false

--- a/lib/ruby-wpdb.rb
+++ b/lib/ruby-wpdb.rb
@@ -15,22 +15,19 @@ module WPDB
     # Given the path to a YAML file, will initialise WPDB using the
     # config files found in that file.
     def from_config(file = nil)
-      file ||= File.dirname(__FILE__) + '/../config.yml'
       config_file = config_file(file)
 
       init(config_file.config[:uri], config_file.config[:prefix])
     end
 
-    def config_file(file)
-      file = Pathname(file)
-      case file.extname
-      when ".yml", ".yaml"
-        config_file = Config::YAML.new(file)
-      when ".php"
-        config_file = Config::WPConfig.new(file)
-      else
-        raise ConfigFileError, "Unknown config file format"
-      end
+    def config_file(file = nil)
+      file = Config::AutoDiscover.new.file unless file
+      raise ConfigFileError, "No config file specified, and none found" unless file
+
+      file = Config::AutoFormat.new(file)
+      raise ConfigFileError, "Unknown config file format for file #{file}" unless file.format
+
+      file
     end
 
     # Initialises Sequel, sets up some necessary variables (like

--- a/lib/ruby-wpdb/config.rb
+++ b/lib/ruby-wpdb/config.rb
@@ -44,5 +44,43 @@ module WPDB
         }
       end
     end
+
+    class AutoDiscover
+      def initialize(directory = Dir.pwd)
+        @directory = Pathname(directory)
+      end
+
+      def file
+        @file ||= files.map { |file| @directory + file }.find { |file| File.exist?(file) }
+      end
+
+      private
+      def files
+        ["wp-config.php", "../wp-config.php", "wp/wp-config.php", "wordpress/wp-config.php", "config.yml"]
+      end
+    end
+
+    class AutoFormat
+      attr_reader :filename
+
+      def initialize(filename)
+        @filename = Pathname(filename)
+      end
+
+      def format
+        case filename.extname
+        when ".yml", ".yaml"
+          Config::YAML
+        when ".php"
+          Config::WPConfig
+        else
+          nil
+        end
+      end
+
+      def config
+        format.new(filename).config
+      end
+    end
   end
 end

--- a/spec/lib/ruby-wpdb_spec.rb
+++ b/spec/lib/ruby-wpdb_spec.rb
@@ -51,20 +51,27 @@ describe WPDB do
 
   describe "#config_file" do
     it "accepts a wp-config.php file" do
-      WPDB::Config::WPConfig.should_receive(:new).with(Pathname("path/to/wp-config.php"))
-      WPDB.config_file("path/to/wp-config.php")
+      WPDB.config_file("path/to/wp-config.php").format.should == WPDB::Config::WPConfig
     end
 
     it "accepts a YAML file" do
-      WPDB::Config::YAML.should_receive(:new).with(Pathname("path/to/config.yml"))
-      WPDB.config_file("path/to/config.yml")
-
-      WPDB::Config::YAML.should_receive(:new).with(Pathname("path/to/config.yaml"))
-      WPDB.config_file("path/to/config.yaml")
+      WPDB.config_file("path/to/config.yml").format.should == WPDB::Config::YAML
+      WPDB.config_file("path/to/config.yaml").format.should == WPDB::Config::YAML
     end
 
     it "raises an error when given an unknown file" do
-      expect { WPDB.config_file("path/to/config.jpg") }.to raise_error(WPDB::ConfigFileError, "Unknown config file format")
+      expect { WPDB.config_file("path/to/config.jpg") }.to raise_error(WPDB::ConfigFileError)
+    end
+
+    it "looks for files if none is given" do
+      File.stub(:exist? => true)
+      WPDB::Config::AutoDiscover.should_receive(:new).and_call_original
+      WPDB.config_file(nil)
+    end
+
+    it "raises an error when given no file and no config files exist" do
+      File.stub(:exist? => false)
+      expect { WPDB.config_file(nil) }.to raise_error(WPDB::ConfigFileError)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ SimpleCov.start
 
 require 'ruby-wpdb'
 
-WPDB.from_config
+WPDB.from_config(Pathname(__FILE__) + ".." + ".." + "config.yml")
 
 RSpec.configure do |c|
   c.around(:each) do |example|


### PR DESCRIPTION
We should look in the current directory (and some levels above/below, maybe?) for a `wp-config.php` file. If it's there, we should initialise WPDB with those settings.
